### PR TITLE
feat: 캔버스, 도형 undo/redo 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,14 @@
           <img src="src/assets/text.svg" alt="text" />
         </button>
       </div>
+      <div id="undoredoTools">
+        <button id="undoButton">
+          <img src="src/assets/undo.svg" alt="undo" />
+        </button>
+        <button id="redoButton">
+          <img src="src/assets/redo.svg" alt="redo" />
+        </button>
+      </div>
     </div>
     <input type="file" id="fileInput" style="display: none;" />
     <script src="./src/app.js" type="module" defer></script>

--- a/src/constant.js
+++ b/src/constant.js
@@ -13,10 +13,14 @@ export const DEFAULT_CANVAS_JSON = {
 };
 
 export const DEFAULT_SHAPE_POSITION = (e) => ({
-    x: e.offsetX,
-    y: e.offsetY,
-    width: 100,
-    height: 100
+    position: {
+        x: e.offsetX,
+        y: e.offsetY,
+    },
+    size: {
+        width: 100,
+        height: 100
+    }
 });
 
 export const DEFAULT_TEXT_DATA = {

--- a/src/controller/Connector.js
+++ b/src/controller/Connector.js
@@ -39,7 +39,7 @@ export default class Connector {
         const object = this.getObjectById(objectId);
         if (object) {
             if (object.getType() === "text") {
-                UIView.renderTextProperties(objectId); 
+                UIView.renderTextProperties(objectId);
             } else {
                 UIView.renderShapeProperties(objectId);
             }
@@ -47,11 +47,14 @@ export default class Connector {
     }
 
     static setToolbarForCanvas() {
-        UIView.resetToolbar();
+        UIView.setCanvasToolbarState();
     }
 
     static getExportData() {
         return Core.Model.getExportData();
     }
-   
+
+    static updateUndoRedoState(undoable, redoable) {
+        UIView.updateUndoRedoState(undoable, redoable);
+    }
 }

--- a/src/controller/actionHandler.js
+++ b/src/controller/actionHandler.js
@@ -1,10 +1,12 @@
 import Connector from "./Connector.js";
+import UIView from "../view/uiView.js";
 
   export default class ActionHandler {
     // canvas
 
     static updateCanvasColor(op) {
         Connector.getCanvas().updateColor(op.value);
+        UIView.setCanvasToolbarState();
     }
 
     static updateCanvasSize(op) {
@@ -26,17 +28,21 @@ import Connector from "./Connector.js";
     }
 
     static insertShape(op) {
-        Connector.getCanvas().addShapeModel(op.shapeType, op.position);
+        Connector.getCanvas().addShapeModel(op.shapeId, op.shapeType, op.position, op.size);
     }
 
     static deleteShape(op) {
-        Connector.getCanvas().deleteShapeModel(op.shapeId);
+        Connector.getCanvas().deleteObjectModel(op.shapeId);
     }
 
     // text
     
     static insertText(op) {
-        Connector.getCanvas().addTextModel(op.textValue, op.textPosition);
+        Connector.getCanvas().addTextModel(op.textId, op.textValue, op.textPosition);
+    }
+
+    static deleteText(op) {
+        Connector.getCanvas().deleteObjectModel(op.textId);
     }
 
     static moveText(op) {

--- a/src/controller/actionManager.js
+++ b/src/controller/actionManager.js
@@ -1,7 +1,57 @@
 import ActionHandler from "./actionHandler.js";
+import Selector from "./selector.js";
+import Connector from "./Connector.js";
+import UIView from "../view/uiView.js";
 
 export default class ActionManager {
-  static executeAction({ op }) {
+  static undoStack = [];
+  static redoStack = [];
+  static isExecutingUndoRedo = false;
+  static undoable = false;
+  static redoable = false;
+
+
+  static executeAction({ op, rOp }) {
     ActionHandler[op.command](op);
+    // undo, redo 수행 중의 스택 추가 방지
+    if (!this.isExecutingUndoRedo) {
+      this.undoStack.push({ op, rOp });
+      console.log("undoStack => ", this.undoStack);
+      this.redoStack = [];
+      this.updateUndoRedoState();
+    }
+    this.isExecutingUndoRedo = false;
+  }
+
+  static getUndoOperation() {
+    if (this.undoStack.length > 0) {
+      const { op, rOp } = this.undoStack.pop();
+      this.redoStack.push({ op, rOp }); // Redo 스택에 추가
+      Selector.clearSelection(); // 핸들 제거
+      this.isExecutingUndoRedo = true;
+      this.updateUndoRedoState();
+
+      return { op: rOp, rOp: op };
+    }
+    return null;
+  }
+
+  static getRedoOperation() {
+    if (this.redoStack.length > 0) {
+      const { op, rOp } = this.redoStack.pop();
+      this.undoStack.push({ op, rOp }); // Undo 스택에 추가
+      Selector.clearSelection(); // 핸들 제거
+      this.isExecutingUndoRedo = true;
+      this.updateUndoRedoState();
+      return { op, rOp };
+    }
+    return null;
+  }
+
+  // Undo/Redo 상태 업데이트 -> Connector -> UIView에 전달
+  static updateUndoRedoState() {
+    const undoable = this.undoStack.length > 0;
+    const redoable = this.redoStack.length > 0;
+    Connector.updateUndoRedoState(undoable, redoable);
   }
 }

--- a/src/controller/selector.js
+++ b/src/controller/selector.js
@@ -86,12 +86,11 @@ export default class Selector {
       },
     ];
   }
-
   static clearSelection() {
     const canvasElement = document.getElementById("canvas");
     const handles = canvasElement.querySelectorAll("[id^='resize_']"); // id에 "resize_" 포함한 요소 검색
-    handles.forEach((marker) => {
-      canvasElement.removeChild(marker);
+    handles.forEach((handle) => {
+      canvasElement.removeChild(handle);
     });
   }
 }

--- a/src/model/canvas.js
+++ b/src/model/canvas.js
@@ -1,6 +1,5 @@
 import Shape from "./shape.js";
 import Text from "./text.js";
-import { nanoid } from 'https://cdn.skypack.dev/nanoid';
 import { DEFAULT_TEXT_DATA } from '../constant.js';
 
 
@@ -62,14 +61,14 @@ export default class Canvas {
     this.notifyListeners("size");
   }
 
-  addShapeModel(shapeType, position) {
+  addShapeModel(shapeId, shapeType, position, size) {
     const shapeData = {
       type: shapeType,
-      id: nanoid(),
+      id: shapeId,
       stroke: { color: "#000000", width: 1 },
       fill: { color: "#ffffff", opacity: 1.0 },
       position: { x: position.x, y: position.y },
-      size: { width: position.width, height: position.height },
+      size: { width: size.width, height: size.height },
       rotation: 0,
       alignment: "center"
     };
@@ -77,19 +76,20 @@ export default class Canvas {
     this.notifyListeners("addingShape");
   }
 
-  deleteShapeModel(shapeId) {
+  deleteObjectModel(shapeId) {
     const index = this.objectList().findIndex(shape => shape.getId() === shapeId);
     this.objectList().splice(index, 1);
     this.notifyListeners("deletingShape", shapeId);
   }
 
-  addTextModel(value, position) {
+  addTextModel(textId, value, position) {
     const textData = {
       ...DEFAULT_TEXT_DATA,
-      id: nanoid(),
+      id: textId,
       textContent: value,
       position: { x: position.x, y: position.y }
     }
+    console.log(textData);
     this.objectList().push(new Text(textData));
     this.notifyListeners("addingText");
   }

--- a/src/model/shape.js
+++ b/src/model/shape.js
@@ -73,7 +73,7 @@ export default class Shape {
         this.listeners.push(listener);
     }
 
-    notifyListeners(changeType) {
+    notifyListeners(changeType, shapeId) {
         this.listeners.forEach((listener) => listener(changeType));
     }
 

--- a/src/view/shapeView.js
+++ b/src/view/shapeView.js
@@ -15,14 +15,6 @@ export default class ShapeView {
     this.newX, this.newY, this.newWidth, this.newHeight;
   }
 
-  // changeType에 따른 업데이트 처리
-  update(changeType) {
-    if (changeType === "position" || changeType === "size") {
-      this.updatePosition();
-    } else if(changeType === "color") {
-      this.updateColor();
-    }
-  }
 
   createSVGElement() {
     const canvasElement = document.getElementById("canvas");
@@ -112,7 +104,9 @@ export default class ShapeView {
 
         const newPosition = { x: finalX, y: finalY };
         // 위치 이동 액션 생성
-        ActionGenerator.updateShapePosition(shape.getId(), newPosition);
+        if(dx, dy !== 0) {
+          ActionGenerator.updateShapePosition(shape.getId(), newPosition);
+        }
         this.isDragging = false;
         this.createResizeHandles();
       } else if (this.isResizing) {
@@ -266,10 +260,19 @@ export default class ShapeView {
     }
   }
 
+  // changeType에 따른 업데이트 처리
+  update(changeType) {
+    if (changeType === "position" || changeType === "size") {
+      this.updatePosition();
+    } else if(changeType === "color") {
+      this.updateColor();
+    }
+  }
+
   // view 업데이트
   updatePosition() {
-    const selectedShape = Connector.getObjectById(Selector.getSelectedObjectId());
-    const shapeElement = document.getElementById(selectedShape.getId());
+    const selectedShape = Connector.getObjectById(this.shape.getId());
+    const shapeElement = document.getElementById(this.shape.getId());
     const { x, y } = selectedShape.position();
     const { width, height } = selectedShape.size();
 
@@ -294,10 +297,10 @@ export default class ShapeView {
   }
 
   updateColor() {
-    const selectedShape = Connector.getObjectById(Selector.getSelectedObjectId());
-    const shapeElement = document.getElementById(selectedShape.getId());
+    // const selectedShape = Connector.getObjectById(Selector.getSelectedObjectId());
+    const shapeElement = document.getElementById(this.shape.getId());
 
-    shapeElement.setAttribute("fill", selectedShape.fillColor())
+    shapeElement.setAttribute("fill", this.shape.fillColor())
   }
 }
 

--- a/src/view/uiView.js
+++ b/src/view/uiView.js
@@ -1,7 +1,6 @@
 import ActionGenerator from "../controller/actionGenerator.js";
 import Connector from "../controller/Connector.js";
 import FileController from "../controller/fileController.js";
-// import JsonLoader from "../controller/jsonLoader.js";
 
 export default class UIView {
   constructor() {
@@ -10,36 +9,26 @@ export default class UIView {
 
   initToolbar() {
     // 캔버스 속성
-    const canvasSize = Connector.getCanvasSize();
-    const canvasColor = Connector.getCanvasColor();
-    this.toolbar = document.getElementById("toolbar");
-    this.canvasToolbar = document.getElementById("canvasToolbar");
-    this.shapeToolbar = document.getElementById("shapeToolbar");
-
     this.colorPicker = document.getElementById("colorPicker");
-    this.colorPicker.value = canvasColor;
-
-    this.widthInput = document.getElementById("widthInput");
-    this.heightInput = document.getElementById("heightInput");
-
-    this.widthInput.value = canvasSize.width;
-    this.heightInput.value = canvasSize.height;
-
     this.confirmButton = document.getElementById("confirmButton");
     this.addTools = document.getElementById("addTools");
 
     this.openButton = document.getElementById("openButton");
     this.saveButton = document.getElementById("saveButton");
     this.fileInput = document.getElementById("fileInput");
+
+    this.undoButton = document.getElementById("undoButton");
+    this.redoButton = document.getElementById("redoButton");
+
+    UIView.updateUndoRedoState(false, false);    
+    UIView.setCanvasToolbarState();
   }
 
   bindToolbarEvents() {
     this.initToolbar();
-
     this.openButton.addEventListener("click", e => this.handleOpenFile(e));
     this.saveButton.addEventListener("click", this.handleSaveFile);
     this.fileInput.addEventListener("change", this.handleFileInput);
-
     // 이벤트 바인딩
     this.colorPicker.addEventListener("input", (event) => this.updateCanvasColor(event));
     this.confirmButton.addEventListener("click", () => this.updateCanvasSize());
@@ -50,7 +39,43 @@ export default class UIView {
         this.addShape(event.target.id);
       }
     });
+    this.undoButton.addEventListener("click", () => this.executeUndo());
+    this.redoButton.addEventListener("click", () => this.executeRedo());
+  }
 
+  static setCanvasToolbarState() {
+    const canvasToolbar = document.getElementById("canvasToolbar");
+    const shapeToolbar = document.getElementById("shapeToolbar");
+
+    const colorPicker = document.getElementById("colorPicker");
+    const widthInput = document.getElementById("widthInput");
+    const heightInput = document.getElementById("heightInput");
+    const canvasSize = Connector.getCanvasSize();
+    const canvasColor = Connector.getCanvasColor();
+
+    canvasToolbar.style.display = "block";
+    shapeToolbar.style.display = "none";
+
+    if (colorPicker) {
+      colorPicker.value = canvasColor;
+    }
+    if (widthInput) {
+      widthInput.value = canvasSize.width;
+    }
+    if (heightInput) {
+      heightInput.value = canvasSize.height;
+    }
+  }
+
+  static updateUndoRedoState(isUndoable, isRedoable) {
+    this.undoButton = document.getElementById("undoButton");
+    this.redoButton = document.getElementById("redoButton");
+
+    this.undoButton.style.opacity = isUndoable ? "1" : "0.3";
+    this.undoButton.style.pointerEvents = isUndoable ? "auto" : "none";
+    
+    this.redoButton.style.opacity = isRedoable ? "1" : "0.3";
+    this.redoButton.style.pointerEvents = isRedoable ? "auto" : "none";
   }
 
   static renderShapeProperties(shapeId) {
@@ -98,15 +123,6 @@ export default class UIView {
     // });
   }
 
-  static resetToolbar() {
-    this.canvasToolbar = document.getElementById("canvasToolbar");
-    this.shapeToolbar = document.getElementById("shapeToolbar");
-
-    this.canvasToolbar.style.display = "block";
-
-    this.shapeToolbar.style.display = "none";
-  }
-
   handleOpenFile = (e) => {
     this.fileInput.click();
   };
@@ -138,8 +154,10 @@ export default class UIView {
   }
 
   updateCanvasSize() {
-    const newWidth = parseInt(this.widthInput.value, 10);
-    const newHeight = parseInt(this.heightInput.value, 10);
+    const widthInput = document.getElementById("widthInput");
+    const heightInput = document.getElementById("heightInput");
+    const newWidth = parseInt(widthInput.value, 10);
+    const newHeight = parseInt(heightInput.value, 10);
     ActionGenerator.updateCanvasSize(newWidth, newHeight);
   }
 
@@ -150,4 +168,13 @@ export default class UIView {
   addText() {
     Connector.setAddingTextMode();
   }
+
+  executeUndo() {
+    ActionGenerator.undo();
+  }
+
+  executeRedo() {
+    ActionGenerator.redo();
+  }
+
 }

--- a/styles.css
+++ b/styles.css
@@ -104,20 +104,27 @@ body {
   #addTools button:hover {
     background-color: #e0e0e0;
   }
-  
-  #undoRedo {
+
+  #undoredoTools {
     display: flex;
     justify-content: center;
     gap: 10px;
+    flex-direction: row;
+    margin-top: 30px;
   }
   
-  #undoRedo button {
+  #undoredoTools button {
     background: none;
     border: none;
     cursor: pointer;
-    font-size: 18px;
+    font-size: 15px;
+    border-radius: 20px;
   }
   
+  #undoredoTools button:hover {
+    background-color: #e0e0e0;
+  }
+
   #canvas {
     /* flex-grow: 1; */
     /* width: 600px;


### PR DESCRIPTION
추가 (11/22 commit)
- undo/redo 에 따른 UIview 갱신
- undo/redo 가능여부에 따른 아이콘 활성화
- undo/redo -> 일단은 따로 새로운 파일 넣지 않고 수정해봤습니다!
- 도형 삭제 시 툴바 갱신

추가 ((11/23 commit)
- actionGenerator 내부 함수 수정
- undo redo 버튼 상태관리 (Connector 이용)
- op, rOp 나머지 기능들 추가
- Text 추가 로직 수정
